### PR TITLE
Implementa Busca de pontos de coleta

### DIFF
--- a/backend/src/main/java/com/ecodb/eco_points/controller/PontoColetaController.java
+++ b/backend/src/main/java/com/ecodb/eco_points/controller/PontoColetaController.java
@@ -1,0 +1,38 @@
+package com.ecodb.eco_points.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ecodb.eco_points.dto.PontoColetaResponseDTO;
+import com.ecodb.eco_points.service.PontoColetaService;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+@RestController
+@RequestMapping("/api/v1/pontos")
+public class PontoColetaController {
+    
+    private PontoColetaService pontoColetaService;
+
+    public PontoColetaController(PontoColetaService pontoColetaService) {
+        this.pontoColetaService = pontoColetaService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('GERADOR')")
+    public ResponseEntity<List<PontoColetaResponseDTO>> listarPontosDeColeta ( 
+        @RequestParam(required = false) String nome,
+        @RequestParam(required = false) Long materialId) {
+        
+            List<PontoColetaResponseDTO> resultadosDaLista = pontoColetaService.buscarPontosDeColeta(nome, materialId);
+
+            return ResponseEntity.ok(resultadosDaLista);
+    }
+    
+}

--- a/backend/src/main/java/com/ecodb/eco_points/dto/PontoColetaResponseDTO.java
+++ b/backend/src/main/java/com/ecodb/eco_points/dto/PontoColetaResponseDTO.java
@@ -1,0 +1,27 @@
+package com.ecodb.eco_points.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ecodb.eco_points.model.Material;
+import com.ecodb.eco_points.model.PontoColeta;
+
+public record PontoColetaResponseDTO(
+    Long id,
+    String nome,
+    String endereco,
+    List<String> materiais
+) {
+    public static PontoColetaResponseDTO fromEntity(PontoColeta pontoColeta) {
+        List<String> nomesMateriais = pontoColeta.getMateriais().stream()
+            .map(Material::getNome)
+            .collect(Collectors.toList());
+        
+            return new PontoColetaResponseDTO(
+                pontoColeta.getId(),
+                pontoColeta.getNome(), 
+                pontoColeta.getEndereco(), 
+                nomesMateriais
+            );
+    }
+}

--- a/backend/src/main/java/com/ecodb/eco_points/repository/PontoColetaRepository.java
+++ b/backend/src/main/java/com/ecodb/eco_points/repository/PontoColetaRepository.java
@@ -1,9 +1,10 @@
 package com.ecodb.eco_points.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.ecodb.eco_points.model.PontoColeta;
 
-public interface PontoColetaRepository extends JpaRepository<PontoColeta, Long> {
-    
+public interface PontoColetaRepository extends JpaRepository<PontoColeta, Long>, JpaSpecificationExecutor<PontoColeta> {
+
 }

--- a/backend/src/main/java/com/ecodb/eco_points/repository/spec/PontoColetaSpecs.java
+++ b/backend/src/main/java/com/ecodb/eco_points/repository/spec/PontoColetaSpecs.java
@@ -1,0 +1,40 @@
+package com.ecodb.eco_points.repository.spec;
+
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+import jakarta.persistence.criteria.Join;
+
+import com.ecodb.eco_points.model.Material;
+import com.ecodb.eco_points.model.PontoColeta;
+
+public class PontoColetaSpecs {
+    public static Specification<PontoColeta> pontosColetaFiltro (String nome, Long materialId) {
+        return (root, query, builder ) -> {
+            query.distinct(true);
+
+            var predicate = builder.conjunction();
+
+            // regra da filtrageem do nome (usando o Like)
+            if (StringUtils.hasText(nome)) {
+                predicate = builder.and(predicate, 
+                    builder.like(
+                        builder.lower(root.get("nome")), 
+                        "%" + nome.toLowerCase() + "%"
+                    )
+                );
+            } 
+
+            // regra do material id (se o id existe ele faz o join e filtra)
+            if (materialId != null) {
+                Join<PontoColeta, Material> materiaisJoin = root.join("materiais");
+                predicate = builder.and(predicate,
+                    builder.equal(materiaisJoin.get("id"), materialId)
+                );
+            }
+
+            query.orderBy(builder.asc(root.get("nome")));
+
+            return predicate;
+        };
+    }
+}

--- a/backend/src/main/java/com/ecodb/eco_points/service/PontoColetaService.java
+++ b/backend/src/main/java/com/ecodb/eco_points/service/PontoColetaService.java
@@ -1,0 +1,28 @@
+package com.ecodb.eco_points.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.ecodb.eco_points.dto.PontoColetaResponseDTO;
+import com.ecodb.eco_points.repository.PontoColetaRepository;
+import com.ecodb.eco_points.repository.spec.PontoColetaSpecs;
+
+@Service
+public class PontoColetaService {
+
+    private PontoColetaRepository pontoColetaRepository;
+
+    public PontoColetaService(PontoColetaRepository pontoColetaRepository) {
+        this.pontoColetaRepository = pontoColetaRepository;
+    }
+
+    public List<PontoColetaResponseDTO> buscarPontosDeColeta(String nome, Long materialId) {
+
+        var pontos = pontoColetaRepository.findAll(PontoColetaSpecs.pontosColetaFiltro(nome, materialId));
+
+        return pontos.stream()
+                .map(PontoColetaResponseDTO::fromEntity)
+                .toList();
+    }
+}


### PR DESCRIPTION
Implementei a busca de pontos de coleta por nome e ID.

Decisões Técnicas:
Optei por usar JPA Specifications por que a query nativa estava gerando conflitos de tipagem no PostgreSQL
O codigo ficou mais limpo e a logica de filtragem ficou na classe `PontoColetaSpecs`

Para testar: 
GET /pontos 
Listar tudo -> (Sem parametros)
Filtrar por nome -> `?nome=centro`
Filtrar por material -> `?materialId=1`

Closes #30 