### PR TITLE
feat: add standardized unit of measurement for materials

### DIFF
--- a/backend/src/main/java/com/ecodb/eco_points/config/DatabaseSeeder.java
+++ b/backend/src/main/java/com/ecodb/eco_points/config/DatabaseSeeder.java
@@ -19,6 +19,7 @@ import com.ecodb.eco_points.model.enums.CategoriaMaterial;
 import com.ecodb.eco_points.model.enums.DestinoMaterial;
 import com.ecodb.eco_points.model.enums.StatusDescarte;
 import com.ecodb.eco_points.model.enums.TipoUsuario;
+import com.ecodb.eco_points.model.enums.UnidadeMedida;
 import com.ecodb.eco_points.repository.DescarteRepository;
 import com.ecodb.eco_points.repository.MaterialRepository;
 import com.ecodb.eco_points.repository.PontoColetaRepository;
@@ -54,16 +55,16 @@ public class DatabaseSeeder implements CommandLineRunner {
         System.out.println("Iniciando o seeder");
 
         List<Material> materiais = Arrays.asList(
-            criarMaterial("Garrafa PET", CategoriaMaterial.PLASTICO, DestinoMaterial.RECICLAGEM),
-            criarMaterial("Caixa de Papelao", CategoriaMaterial.PAPEL, DestinoMaterial.RECICLAGEM),
-            criarMaterial("Lata de refrigerante", CategoriaMaterial.METAL, DestinoMaterial.RECICLAGEM),
-            criarMaterial("Garrafa de Vidro", CategoriaMaterial.VIDRO, DestinoMaterial.RECICLAGEM),
-            criarMaterial("Casca de Fruta/Legume", CategoriaMaterial.ORGANICO, DestinoMaterial.COMPOSTAGEM),
-            criarMaterial("resto de Comida", CategoriaMaterial.ORGANICO, DestinoMaterial.COMPOSTAGEM),
-            criarMaterial("oleo de Cozinha Usado", CategoriaMaterial.OLEO, DestinoMaterial.DESCARTE_ESPECIAL),
-            criarMaterial("Pilhas e Baterias", CategoriaMaterial.ELETRONICO, DestinoMaterial.DESCARTE_ESPECIAL),
-            criarMaterial("Celular Quebrado", CategoriaMaterial.ELETRONICO, DestinoMaterial.REUSO),
-            criarMaterial("pote de Vidro (Conserva)", CategoriaMaterial.VIDRO, DestinoMaterial.REUSO)
+            criarMaterial("Garrafa PET", CategoriaMaterial.PLASTICO, DestinoMaterial.RECICLAGEM, UnidadeMedida.UNIDADE),
+            criarMaterial("Caixa de Papelao", CategoriaMaterial.PAPEL, DestinoMaterial.RECICLAGEM, UnidadeMedida.KILOGRAMA),
+            criarMaterial("Lata de refrigerante", CategoriaMaterial.METAL, DestinoMaterial.RECICLAGEM, UnidadeMedida.UNIDADE),
+            criarMaterial("Garrafa de Vidro", CategoriaMaterial.VIDRO, DestinoMaterial.RECICLAGEM, UnidadeMedida.KILOGRAMA),
+            criarMaterial("Casca de Fruta/Legume", CategoriaMaterial.ORGANICO, DestinoMaterial.COMPOSTAGEM, UnidadeMedida.KILOGRAMA),
+            criarMaterial("resto de Comida", CategoriaMaterial.ORGANICO, DestinoMaterial.COMPOSTAGEM, UnidadeMedida.KILOGRAMA),
+            criarMaterial("oleo de Cozinha Usado", CategoriaMaterial.OLEO, DestinoMaterial.DESCARTE_ESPECIAL, UnidadeMedida.LITRO),
+            criarMaterial("Pilhas e Baterias", CategoriaMaterial.ELETRONICO, DestinoMaterial.DESCARTE_ESPECIAL, UnidadeMedida.UNIDADE),
+            criarMaterial("Celular Quebrado", CategoriaMaterial.ELETRONICO, DestinoMaterial.REUSO, UnidadeMedida.UNIDADE),
+            criarMaterial("pote de Vidro (Conserva)", CategoriaMaterial.VIDRO, DestinoMaterial.REUSO, UnidadeMedida.UNIDADE)
         );
         materialRepository.saveAll(materiais);
         System.out.println("Materiais criados.");
@@ -111,35 +112,38 @@ public class DatabaseSeeder implements CommandLineRunner {
         System.out.println("Ponto de Coleta criado.");
 
         // CRIAR DESCARTES
+        Material materialPet = encontrarMaterial(materiais, "Garrafa PET");
         Descarte descarte1 = new Descarte();
         descarte1.setDescricaoEspecifica("3 sacolas de garrafas");
-        descarte1.setQuantidade(2.5);
-        descarte1.setUnidadeMedida("KG");
+        descarte1.setQuantidade(15.0);
+        descarte1.setUnidadeMedida(materialPet.getUnidadePadrao()); // UNIDADE
         descarte1.setStatus(StatusDescarte.PENDENTE);
         descarte1.setUsuario(joao);
         descarte1.setPontoColeta(ecoponto);
-        descarte1.setMaterial(encontrarMaterial(materiais, "Garrafa PET"));
+        descarte1.setMaterial(materialPet);
         descarte1.setDataCriacao(LocalDateTime.now().minusDays(1));
 
+        Material materialPilhas = encontrarMaterial(materiais, "Pilhas e Baterias");
         Descarte descarte2 = new Descarte();
         descarte2.setDescricaoEspecifica("Pilha velha de controle");
         descarte2.setQuantidade(4.0);
-        descarte2.setUnidadeMedida("UNIDADE");
+        descarte2.setUnidadeMedida(materialPilhas.getUnidadePadrao()); // UNIDADE
         descarte2.setStatus(StatusDescarte.CONCLUIDO);
         descarte2.setUsuario(joao);
         descarte2.setPontoColeta(ecoponto);
-        descarte2.setMaterial(encontrarMaterial(materiais, "Pilhas e Baterias"));
+        descarte2.setMaterial(materialPilhas);
         descarte2.setDataCriacao(LocalDateTime.now().minusDays(5));
 
         descarteRepository.saveAll(Arrays.asList(descarte1, descarte2));
         System.out.println("Descartes criados.");
     }
     
-    private Material criarMaterial(String nome, CategoriaMaterial categoriaMaterial, DestinoMaterial destinoMaterial) {
+    private Material criarMaterial(String nome, CategoriaMaterial categoriaMaterial, DestinoMaterial destinoMaterial, UnidadeMedida unidadePadrao) {
         Material material = new Material();
         material.setNome(nome);
         material.setCategoria(categoriaMaterial);
         material.setDestino(destinoMaterial);
+        material.setUnidadePadrao(unidadePadrao);
         return material;
     }
 

--- a/backend/src/main/java/com/ecodb/eco_points/dto/DescarteDTO.java
+++ b/backend/src/main/java/com/ecodb/eco_points/dto/DescarteDTO.java
@@ -16,9 +16,6 @@ public record DescarteDTO (
     @Positive(message = "A quantidade deve ser um valor positivo")
     Double quantidade,
 
-    @NotBlank(message = "A unidade de medida é obrigatória")
-    String unidadeMedida,
-
     String descricao
 ) {}
 

--- a/backend/src/main/java/com/ecodb/eco_points/dto/DescarteResponseDTO.java
+++ b/backend/src/main/java/com/ecodb/eco_points/dto/DescarteResponseDTO.java
@@ -25,7 +25,7 @@ public record DescarteResponseDTO(
             descarte.getId(),
             descarte.getDescricaoEspecifica(),
             descarte.getQuantidade(),
-            descarte.getUnidadeMedida(),
+            descarte.getUnidadeMedida().getAbreviacao(),
             descarte.getStatus(),
             descarte.getDataCriacao(),
             descarte.getMaterial().getNome(),

--- a/backend/src/main/java/com/ecodb/eco_points/model/Descarte.java
+++ b/backend/src/main/java/com/ecodb/eco_points/model/Descarte.java
@@ -3,6 +3,7 @@ package com.ecodb.eco_points.model;
 import java.time.LocalDateTime;
 
 import com.ecodb.eco_points.model.enums.StatusDescarte;
+import com.ecodb.eco_points.model.enums.UnidadeMedida;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,8 +33,9 @@ public class Descarte {
     @Column(nullable = false)
     private double quantidade;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String unidadeMedida = "KG";
+    private UnidadeMedida unidadeMedida;
 
     @Enumerated(EnumType.STRING)
     private StatusDescarte status = StatusDescarte.PENDENTE;

--- a/backend/src/main/java/com/ecodb/eco_points/model/Material.java
+++ b/backend/src/main/java/com/ecodb/eco_points/model/Material.java
@@ -2,6 +2,7 @@ package com.ecodb.eco_points.model;
 
 import com.ecodb.eco_points.model.enums.CategoriaMaterial;
 import com.ecodb.eco_points.model.enums.DestinoMaterial;
+import com.ecodb.eco_points.model.enums.UnidadeMedida;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,5 +35,9 @@ public class Material {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DestinoMaterial destino;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UnidadeMedida unidadePadrao;
     
 }

--- a/backend/src/main/java/com/ecodb/eco_points/model/enums/UnidadeMedida.java
+++ b/backend/src/main/java/com/ecodb/eco_points/model/enums/UnidadeMedida.java
@@ -1,0 +1,17 @@
+package com.ecodb.eco_points.model.enums;
+
+public enum UnidadeMedida {
+    KILOGRAMA("kg"),
+    LITRO("L"),
+    UNIDADE("Un");
+
+    private final String abreviacao;
+
+    UnidadeMedida(String abreviacao) {
+        this.abreviacao = abreviacao;
+    }
+
+    public String getAbreviacao() {
+        return abreviacao;
+    }
+}

--- a/backend/src/main/java/com/ecodb/eco_points/service/DescarteService.java
+++ b/backend/src/main/java/com/ecodb/eco_points/service/DescarteService.java
@@ -62,7 +62,7 @@ public class DescarteService {
                 descarte.setUsuario(usuario);
                 descarte.setDescricaoEspecifica(dto.descricao());
                 descarte.setQuantidade(dto.quantidade());
-                descarte.setUnidadeMedida(dto.unidadeMedida());
+                descarte.setUnidadeMedida(material.getUnidadePadrao()); // Usa unidade padrão do material
                 descarte.setStatus(StatusDescarte.PENDENTE);
                 descarte.setDataCriacao(LocalDateTime.now());
 


### PR DESCRIPTION
- Create UnidadeMedida enum (KILOGRAMA, LITRO, UNIDADE)
- Add unidadePadrao field to Material entity
- Update Descarte to use UnidadeMedida enum instead of String
- Remove unidadeMedida from DescarteDTO (auto-assigned from material)
- Update DescarteService to automatically use material's default unit
- Update seeder with correct units for each material


closes #38 