### PR TITLE
fix: map backend status (CONCLUIDO/CANCELADO) to frontend labels 

### DIFF
--- a/frontend/src/components/coletor/PontoModal.jsx
+++ b/frontend/src/components/coletor/PontoModal.jsx
@@ -136,7 +136,7 @@ export default function PontoModal({ isOpen, onClose, onSubmit, editingPonto = n
             </label>
             <input
               type="text"
-              placeholder="Ex: Rua das Flores, 123 (Mínimo 10 caracteres)"
+              placeholder="Ex: Rua das Flores, 123 - São Paulo (Mínimo 10 caracteres)"
               value={formData.endereco}
               minLength={10}
               onChange={(e) => {

--- a/frontend/src/components/descartes/DescarteCard.jsx
+++ b/frontend/src/components/descartes/DescarteCard.jsx
@@ -3,7 +3,9 @@ import { Trash2, Calendar } from 'lucide-react';
 import StatusBadge from './StatusBadge';
 
 const displayStatus = (status) => {
-    return status === 'CONCLUIDO' ? 'APROVADO' : status;
+    if (status === 'CONCLUIDO') return 'APROVADO';
+    if (status === 'CANCELADO') return 'NEGADO';
+    return status;
 };
 
 export default function DescarteCard({ descarte, onCancel }) {

--- a/frontend/src/components/descartes/StatusBadge.jsx
+++ b/frontend/src/components/descartes/StatusBadge.jsx
@@ -6,7 +6,8 @@ export default function StatusBadge({ status }) {
     'APROVADO': { bg: 'bg-green-100', text: 'text-green-800', icon: <CheckCircle className="w-3 h-3" />, label: 'Aprovado' },
     'PENDENTE': { bg: 'bg-[#FEF9C3]', text: 'text-yellow-800', icon: <Clock className="w-3 h-3" />, label: 'Pendente' },
     'NEGADO': { bg: 'bg-red-100', text: 'text-red-800', icon: <XCircle className="w-3 h-3" />, label: 'Negado' },
-    'CONCLUIDO': { bg: 'bg-blue-100', text: 'text-blue-800', icon: <CheckCircle className="w-3 h-3" />, label: 'Concluído' },
+    'CONCLUIDO': { bg: 'bg-green-100', text: 'text-green-800', icon: <CheckCircle className="w-3 h-3" />, label: 'Aprovado' },
+    'CANCELADO': { bg: 'bg-red-100', text: 'text-red-800', icon: <XCircle className="w-3 h-3" />, label: 'Negado' },
   };
   
   const config = styles[status] || styles['PENDENTE'];

--- a/frontend/src/components/gerador/HistorySidebar.jsx
+++ b/frontend/src/components/gerador/HistorySidebar.jsx
@@ -9,9 +9,16 @@ export default function HistorySidebar({ descartes }) {
       'APROVADO': 'text-green-700 bg-green-50 border-green-200',
       'PENDENTE': 'text-yellow-700 bg-yellow-50 border-yellow-200',
       'NEGADO': 'text-red-700 bg-red-50 border-red-200',
-      'CONCLUIDO': 'text-blue-700 bg-blue-50 border-blue-200'
+      'CONCLUIDO': 'text-green-700 bg-green-50 border-green-200',
+      'CANCELADO': 'text-red-700 bg-red-50 border-red-200'
     };
     return map[status] || 'text-gray-600 bg-gray-50';
+  };
+
+  const getStatusLabel = (status) => {
+    if (status === 'CONCLUIDO') return 'APROVADO';
+    if (status === 'CANCELADO') return 'NEGADO';
+    return status;
   };
 
   return (
@@ -31,7 +38,7 @@ export default function HistorySidebar({ descartes }) {
                 {d.materialNome || 'Material'} 
               </span>
               <span className={`px-2 py-0.5 rounded text-[10px] font-bold border uppercase tracking-wide ${getStatusColor(d.status)}`}>
-                {d.status}
+                {getStatusLabel(d.status)}
               </span>
             </div>
             <div className="text-sm text-gray-500 space-y-1">

--- a/frontend/src/components/profile/EditForm.jsx
+++ b/frontend/src/components/profile/EditForm.jsx
@@ -61,7 +61,7 @@ export default function EditForm({ formData, handleChange, handleSubmit, loading
           onChange={handleChange}
           rows={3}
           className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent transition resize-none"
-          placeholder="Rua, número, bairro, cidade"
+          placeholder="Ex: Rua das Flores, 123 - São Paulo (Mínimo 10 caracteres)"
           maxLength={200}
         />
         <p className="mt-1 text-sm text-gray-500">

--- a/frontend/src/pages/MeusDescartes.jsx
+++ b/frontend/src/pages/MeusDescartes.jsx
@@ -42,7 +42,10 @@ export default function MeusDescartes() {
     ? descartes 
     : descartes.filter(d => {
         if (filterStatus === 'APROVADO') {
-          return d.status === 'CONCLUIDO';
+          return d.status === 'CONCLUIDO' || d.status === 'APROVADO' || d.status === 'AGENDADO';
+        }
+        if (filterStatus === 'NEGADO') {
+          return d.status === 'CANCELADO' || d.status === 'NEGADO';
         }
         
         return d.status === filterStatus;  

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -65,7 +65,7 @@ export default function Profile() {
   const countTotal = userType === 'COLETOR' ? pontos.length : descartes.length;
   const countAprovados = userType === 'COLETOR' 
     ? pontos.filter(p => p.ativo !== false).length
-    : descartes.filter(d => d.status === 'APROVADO' || d.status === 'CONCLUIDO').length;
+    : descartes.filter(d => d.status === 'APROVADO' || d.status === 'CONCLUIDO' || d.status === 'AGENDADO').length;
   const countMateriais = userType === 'COLETOR' ? materiaisUnicos.size : 0;
 
   if (loading) {


### PR DESCRIPTION

- Update StatusBadge to display "Aprovado" for CONCLUIDO and "Negado" for CANCELADO
- Fix HistorySidebar to show correct status labels instead of raw backend values
- Update MeusDescartes filter to include CANCELADO when filtering by NEGADO
- Add getStatusLabel helper function to normalize status display
- Ensure all status filters work correctly across the generator interface
- Update approved counter in Profile to include AGENDADO status